### PR TITLE
Move back-end code to a view model

### DIFF
--- a/src/main/kotlin/CounterViewModel.kt
+++ b/src/main/kotlin/CounterViewModel.kt
@@ -1,0 +1,32 @@
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.microsoft.signalr.HubConnectionBuilder
+import core.ViewModel
+import kotlinx.coroutines.launch
+
+class CounterViewModel : ViewModel() {
+  var counterValue: Int by mutableStateOf(0)
+    private set
+
+  val isDecrementEnabled: Boolean by derivedStateOf { counterValue > 0 }
+  val isIncrementEnabled: Boolean by derivedStateOf { counterValue < 8 }
+
+  private val hubConnection = HubConnectionBuilder.create("https://sats-test-no-bagel.azurewebsites.net/api").build()
+
+  init {
+    viewModelScope.launch {
+      hubConnection.on("UpdatedBagelCount", { newValue: Int -> counterValue = newValue }, Int::class.java)
+      hubConnection.start().blockingAwait()
+    }
+  }
+
+  fun onIncrementClicked() {
+    hubConnection.send("IncrementBagelCount")
+  }
+
+  fun onDecrementClicked() {
+    hubConnection.send("DecrementBagelCount")
+  }
+}

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -9,7 +9,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -22,19 +22,12 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
-import com.microsoft.signalr.*
+import core.viewModel
 
 @Composable
 @Preview
 fun App() {
-  var counter by remember {
-    mutableStateOf(0) }
-  var hubConnection = remember {
-    var hubConnection  = HubConnectionBuilder.create("https://sats-test-no-bagel.azurewebsites.net/api").build()
-    hubConnection.on("UpdatedBagelCount", Action1 {b: Int -> counter = b}, Int::class.java)
-    hubConnection.start().blockingAwait()
-    hubConnection
-  }
+  val viewModel = viewModel { CounterViewModel() }
 
   Surface(color = Color.Black, contentColor = Color.White) {
     Row(
@@ -48,7 +41,7 @@ fun App() {
       Text("Bagel counter", Modifier.padding(start = 74.dp), fontSize = 56.sp)
 
       Text(
-        text = counter.toString(),
+        text = viewModel.counterValue.toString(),
         modifier = Modifier.padding(start = 110.dp),
         fontSize = 76.sp,
         fontWeight = FontWeight.Bold
@@ -62,11 +55,19 @@ fun App() {
           .background(color = Color(0xFFC4C4C4))
       )
 
-      IconButton(onClick = { hubConnection.send("DecrementBagelCount") }, Modifier.padding(start = 60.dp), enabled = counter > 0) {
+      IconButton(
+        modifier = Modifier.padding(start = 60.dp),
+        onClick = viewModel::onDecrementClicked,
+        enabled = viewModel.isDecrementEnabled
+      ) {
         Icon(Icons.Outlined.ExpandMore, contentDescription = null, Modifier.size(104.dp))
       }
 
-      IconButton(onClick = { hubConnection.send("IncrementBagelCount") }, Modifier.padding(start = 21.dp, end = 77.dp), enabled = counter < 8) {
+      IconButton(
+        modifier = Modifier.padding(start = 21.dp, end = 77.dp),
+        onClick = viewModel::onIncrementClicked,
+        enabled = viewModel.isIncrementEnabled
+      ) {
         Icon(Icons.Outlined.ExpandLess, contentDescription = null, Modifier.size(104.dp))
       }
     }

--- a/src/main/kotlin/core/ViewModel.kt
+++ b/src/main/kotlin/core/ViewModel.kt
@@ -1,0 +1,28 @@
+package core
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelChildren
+
+abstract class ViewModel {
+  private val coroutineContext = Job()
+  protected val viewModelScope = CoroutineScope(coroutineContext)
+
+  fun dispose() {
+    coroutineContext.cancelChildren()
+  }
+}
+
+@Composable
+fun <T : ViewModel> viewModel(builder: () -> T): T {
+  val viewModel = remember { builder() }
+
+  DisposableEffect(Unit) {
+    onDispose { viewModel.dispose() }
+  }
+
+  return viewModel
+}


### PR DESCRIPTION
To clean up listening to the SignalR back-end, move its logic into a separate view model.