### PR TITLE
Include missing java.sql module in builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,8 @@ compose.desktop {
     mainClass = "MainKt"
 
     nativeDistributions {
+      modules("java.sql")
+
       targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
 
       packageName = "bagels"


### PR DESCRIPTION
As per the documentation at https://github.com/JetBrains/compose-jb/tree/master/tutorials/Native_distributions_and_local_execution#configuring-included-jdk-modules. Who reads docs anyway, right?